### PR TITLE
Use shutil.copy2() to preserve file meta

### DIFF
--- a/pylogrotate/main.py
+++ b/pylogrotate/main.py
@@ -225,7 +225,7 @@ class Rotator(object):
             makedirs(dest_dir, 0o755)
             chown(dest_dir, self.user, self.group)
         if path.startswith(from_):
-            shutil.copy(path, dest)
+            shutil.copy2(path, dest)
 
     def copy_file(self, dest_path):
         if isinstance(self.copy, dict):

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='pylogrotate',
-    version='0.0.11',
+    version='0.0.12',
     description='Logrotate in Python',
     author='gfreezy',
     author_email='gfreezy@gmail.com',


### PR DESCRIPTION
`copy()` 是单纯的拷贝，`copy2()` 会保留文件的 meta 信息，用 `rsync` 等工具同步时可以跳过相同文件

```
# copy
$ echo copy > copy; sleep 1
$ python -c 'import shutil; shutil.copy("copy", "/tmp/")'
$ rsync -avP copy /tmp/
sending incremental file list
copy
              5 100%    0.00kB/s    0:00:00 (xfr#1, to-chk=0/1)

sent 111 bytes  received 35 bytes  292.00 bytes/sec
total size is 5  speedup is 0.03

# copy2
$ echo copy2 > copy2; sleep 1
$ python -c 'import shutil; shutil.copy2("copy2", "/tmp/")'
$ rsync -avP copy2 /tmp/
sending incremental file list

sent 60 bytes  received 12 bytes  144.00 bytes/sec
total size is 6  speedup is 0.08
```